### PR TITLE
Migrate error handling to thiserror library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,15 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,7 +1705,6 @@ dependencies = [
 name = "whatawhat-lib"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "derive_builder",
  "freedesktop-desktop-entry",
@@ -1727,6 +1717,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/Anoromi/whatawhat-lib"
 
 
 [dependencies]
-anyhow = { version = "1.0.98", features = ["backtrace"] }
+thiserror = "2"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.36.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,594 @@
+//! Error types for the whatawhat-lib crate.
+//!
+//! This module provides a structured error type with an inner `ErrorKind` enum
+//! that categorizes different error conditions. The outer `Error` struct is
+//! designed for future extensibility (e.g., adding context, backtraces, etc.).
+
+use std::fmt;
+
+/// The main error type for this crate.
+///
+/// This struct wraps an `ErrorKind` and is designed for future extensibility.
+/// Additional context or metadata can be added to this struct without breaking
+/// the public API.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+impl Error {
+    /// Create a new error from an error kind.
+    pub fn new(kind: ErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Returns the kind of this error.
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
+
+    /// Consumes this error and returns the underlying error kind.
+    pub fn into_kind(self) -> ErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.kind)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.kind.source()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+// Blanket From implementations for external error types.
+// These allow the `?` operator to convert external errors to our Error type directly.
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        ErrorKind::Io(err).into()
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        ErrorKind::Json(err).into()
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(err: std::num::ParseIntError) -> Self {
+        ErrorKind::ParseInt(err).into()
+    }
+}
+
+impl From<std::env::VarError> for Error {
+    fn from(err: std::env::VarError) -> Self {
+        ErrorKind::EnvVar(err).into()
+    }
+}
+
+#[cfg(feature = "x11")]
+impl From<xcb::Error> for Error {
+    fn from(err: xcb::Error) -> Self {
+        ErrorKind::Xcb(err).into()
+    }
+}
+
+#[cfg(feature = "x11")]
+impl From<xcb::ConnError> for Error {
+    fn from(err: xcb::ConnError) -> Self {
+        ErrorKind::XcbConnection(err).into()
+    }
+}
+
+#[cfg(any(feature = "gnome", feature = "kde"))]
+impl From<zbus::Error> for Error {
+    fn from(err: zbus::Error) -> Self {
+        ErrorKind::Zbus(err).into()
+    }
+}
+
+#[cfg(feature = "wayland")]
+impl From<wayland_client::backend::WaylandError> for Error {
+    fn from(err: wayland_client::backend::WaylandError) -> Self {
+        ErrorKind::WaylandBackend(err).into()
+    }
+}
+
+#[cfg(feature = "wayland")]
+impl From<wayland_client::ConnectError> for Error {
+    fn from(err: wayland_client::ConnectError) -> Self {
+        ErrorKind::WaylandConnect(err).into()
+    }
+}
+
+#[cfg(feature = "wayland")]
+impl From<wayland_client::DispatchError> for Error {
+    fn from(err: wayland_client::DispatchError) -> Self {
+        ErrorKind::WaylandDispatch(err).into()
+    }
+}
+
+#[cfg(feature = "wayland")]
+impl From<wayland_client::globals::GlobalError> for Error {
+    fn from(err: wayland_client::globals::GlobalError) -> Self {
+        ErrorKind::WaylandGlobal(err).into()
+    }
+}
+
+#[cfg(feature = "wayland")]
+impl From<wayland_client::globals::BindError> for Error {
+    fn from(err: wayland_client::globals::BindError) -> Self {
+        ErrorKind::WaylandBind(err).into()
+    }
+}
+
+#[cfg(feature = "win")]
+impl From<windows::core::Error> for Error {
+    fn from(err: windows::core::Error) -> Self {
+        ErrorKind::Windows(err).into()
+    }
+}
+
+/// Categorizes the different types of errors that can occur.
+#[derive(Debug, thiserror::Error)]
+pub enum ErrorKind {
+    // ========================
+    // General / Initialization
+    // ========================
+    /// No window manager was selected or available.
+    #[error("no window manager was selected or available")]
+    NoWindowManager,
+
+    /// The current display server should use X11 instead.
+    #[error("X11 should be used instead of the current backend")]
+    ShouldUseX11,
+
+    // ========================
+    // Window Operations
+    // ========================
+    /// Failed to get the foreground window.
+    #[error("failed to get the foreground window")]
+    ForegroundWindowNotFound,
+
+    /// Failed to get the active window.
+    #[error("failed to get the active window: {0}")]
+    ActiveWindowNotFound(String),
+
+    /// The current window is unknown (no window has been activated yet).
+    #[error("the current window is unknown (no window has been activated yet)")]
+    CurrentWindowUnknown,
+
+    /// A window was not found by its ID.
+    #[error("window not found by ID: {0}")]
+    WindowNotFoundById(String),
+
+    /// Failed to get the window process ID.
+    #[error("failed to get the window process ID")]
+    ProcessIdNotFound,
+
+    /// Failed to get the process name.
+    #[error("failed to get the process name for the window")]
+    ProcessNameNotFound,
+
+    // ========================
+    // Idle Detection
+    // ========================
+    /// Failed to retrieve user idle time.
+    #[error("failed to retrieve user idle time")]
+    IdleTimeRetrievalFailed,
+
+    /// Failed to get idle time from DBus.
+    #[error("failed to get idle time from DBus: {0}")]
+    DbusIdleTimeFailed(String),
+
+    /// Failed to deserialize idle time.
+    #[error("failed to deserialize idle time response")]
+    IdleTimeDeserializationFailed,
+
+    // ========================
+    // X11 Specific
+    // ========================
+    /// X11 connection error.
+    #[error("X11 connection error: {0}")]
+    X11Connection(String),
+
+    /// Invalid X11 screen configuration.
+    #[error("invalid X11 screen: preferred screen is negative ({0})")]
+    X11InvalidScreen(i32),
+
+    // ========================
+    // Wayland Specific
+    // ========================
+    /// Failed to connect to the Wayland compositor.
+    #[error("failed to connect to the Wayland compositor")]
+    WaylandConnectionFailed,
+
+    /// Wayland event queue processing failed.
+    #[error("Wayland event queue processing failed: {0}")]
+    WaylandEventQueueFailed(String),
+
+    /// Failed to bind a Wayland global.
+    #[error("failed to bind Wayland global: {0}")]
+    WaylandGlobalBindFailed(String),
+
+    // ========================
+    // GNOME Specific
+    // ========================
+    /// The runtime doesn't appear to be GNOME.
+    #[error("the runtime doesn't appear to be GNOME")]
+    NotGnomeRuntime,
+
+    /// The GNOME extension appears to have stopped.
+    #[error("the GNOME extension appears to have stopped responding")]
+    GnomeExtensionStopped,
+
+    /// Failed to parse DBus response.
+    #[error("failed to parse DBus response: {0}")]
+    DbusResponseParseFailed(String),
+
+    /// DBus call failed.
+    #[error("DBus call failed: {0}")]
+    DbusCallFailed(String),
+
+    /// Failed to install GNOME extension.
+    #[error("failed to install GNOME extension")]
+    GnomeExtensionInstallFailed,
+
+    /// Failed to activate GNOME extension.
+    #[error("failed to activate GNOME extension")]
+    GnomeExtensionActivateFailed,
+
+    // ========================
+    // KDE Specific
+    // ========================
+    /// Failed to create KWin script.
+    #[error("failed to create KWin script: {0}")]
+    KwinScriptCreationFailed(String),
+
+    /// Failed to start KWin script.
+    #[error("failed to start KWin script")]
+    KwinScriptStartFailed,
+
+    /// KWin version not found.
+    #[error("KWin version not found in support information")]
+    KwinVersionNotFound,
+
+    /// KWin version is invalid.
+    #[error("KWin version is invalid: {0}")]
+    KwinVersionInvalid(String),
+
+    /// Failed to run DBus interface.
+    #[error("failed to run DBus interface: {0}")]
+    DbusInterfaceFailed(String),
+
+    /// Temporary file path is not valid UTF-8.
+    #[error("temporary file path is not valid UTF-8")]
+    InvalidTempPath,
+
+    // ========================
+    // macOS Specific
+    // ========================
+    /// OSAScript execution error.
+    #[error("OSAScript execution error: {0}")]
+    OsaScriptExecutionFailed(String),
+
+    /// OSAScript compilation error.
+    #[error("OSAScript compilation error: {0}")]
+    OsaScriptCompilationFailed(String),
+
+    /// No result from OSAScript execution.
+    #[error("no result returned from OSAScript execution")]
+    OsaScriptNoResult,
+
+    /// OSAScript did not return a string value.
+    #[error("OSAScript did not return a string value")]
+    OsaScriptNotString,
+
+    /// Failed to parse JXA JSON output.
+    #[error("failed to parse JXA JSON: {reason}; payload: {payload}")]
+    JxaJsonParseFailed { reason: String, payload: String },
+
+    /// No app info was loaded.
+    #[error("no app info was loaded from the background process")]
+    NoAppInfoLoaded,
+
+    /// Failed to get JavaScript OSALanguage.
+    #[error("failed to get JavaScript OSALanguage")]
+    OsaLanguageNotFound,
+
+    /// macOS permissions may be denied (startup error).
+    #[error("macOS startup error (permissions may be denied): {0}")]
+    MacosStartupFailed(String),
+
+    // ========================
+    // I/O and System Errors
+    // ========================
+    /// I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON parsing error.
+    #[error("JSON parsing error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Integer parsing error.
+    #[error("integer parsing error: {0}")]
+    ParseInt(#[from] std::num::ParseIntError),
+
+    /// Environment variable error.
+    #[error("environment variable error: {0}")]
+    EnvVar(#[from] std::env::VarError),
+
+    // ========================
+    // External Library Errors
+    // ========================
+    /// XCB (X11) protocol error.
+    #[cfg(feature = "x11")]
+    #[error("XCB protocol error: {0}")]
+    Xcb(#[from] xcb::Error),
+
+    /// XCB connection error.
+    #[cfg(feature = "x11")]
+    #[error("XCB connection error: {0}")]
+    XcbConnection(#[from] xcb::ConnError),
+
+    /// ZBus (DBus) error.
+    #[cfg(any(feature = "gnome", feature = "kde"))]
+    #[error("DBus error: {0}")]
+    Zbus(#[from] zbus::Error),
+
+    /// Wayland backend error.
+    #[cfg(feature = "wayland")]
+    #[error("Wayland backend error: {0}")]
+    WaylandBackend(#[from] wayland_client::backend::WaylandError),
+
+    /// Wayland connection error.
+    #[cfg(feature = "wayland")]
+    #[error("Wayland connection error: {0}")]
+    WaylandConnect(#[from] wayland_client::ConnectError),
+
+    /// Wayland dispatch error.
+    #[cfg(feature = "wayland")]
+    #[error("Wayland dispatch error: {0}")]
+    WaylandDispatch(#[from] wayland_client::DispatchError),
+
+    /// Wayland global error.
+    #[cfg(feature = "wayland")]
+    #[error("Wayland global error: {0}")]
+    WaylandGlobal(#[from] wayland_client::globals::GlobalError),
+
+    /// Wayland bind error.
+    #[cfg(feature = "wayland")]
+    #[error("Wayland bind error: {0}")]
+    WaylandBind(#[from] wayland_client::globals::BindError),
+
+    /// Windows API error.
+    #[cfg(feature = "win")]
+    #[error("Windows API error: {0}")]
+    Windows(#[from] windows::core::Error),
+}
+
+/// A specialized Result type for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+// ========================
+// Convenience constructors
+// ========================
+
+impl Error {
+    /// Creates an error for when no window manager is available.
+    pub fn no_window_manager() -> Self {
+        ErrorKind::NoWindowManager.into()
+    }
+
+    /// Creates an error indicating X11 should be used instead.
+    pub fn should_use_x11() -> Self {
+        ErrorKind::ShouldUseX11.into()
+    }
+
+    /// Creates an error for when the foreground window cannot be found.
+    pub fn foreground_window_not_found() -> Self {
+        ErrorKind::ForegroundWindowNotFound.into()
+    }
+
+    /// Creates an error for when the active window cannot be found.
+    pub fn active_window_not_found(details: impl Into<String>) -> Self {
+        ErrorKind::ActiveWindowNotFound(details.into()).into()
+    }
+
+    /// Creates an error for when the current window is unknown.
+    pub fn current_window_unknown() -> Self {
+        ErrorKind::CurrentWindowUnknown.into()
+    }
+
+    /// Creates an error for when a window is not found by ID.
+    pub fn window_not_found_by_id(id: impl Into<String>) -> Self {
+        ErrorKind::WindowNotFoundById(id.into()).into()
+    }
+
+    /// Creates an error for when the process ID cannot be found.
+    pub fn process_id_not_found() -> Self {
+        ErrorKind::ProcessIdNotFound.into()
+    }
+
+    /// Creates an error for when the process name cannot be found.
+    pub fn process_name_not_found() -> Self {
+        ErrorKind::ProcessNameNotFound.into()
+    }
+
+    /// Creates an error for idle time retrieval failure.
+    pub fn idle_time_retrieval_failed() -> Self {
+        ErrorKind::IdleTimeRetrievalFailed.into()
+    }
+
+    /// Creates an error for DBus idle time failure.
+    pub fn dbus_idle_time_failed(details: impl Into<String>) -> Self {
+        ErrorKind::DbusIdleTimeFailed(details.into()).into()
+    }
+
+    /// Creates an error for idle time deserialization failure.
+    pub fn idle_time_deserialization_failed() -> Self {
+        ErrorKind::IdleTimeDeserializationFailed.into()
+    }
+
+    /// Creates an error for X11 connection issues.
+    #[cfg(feature = "x11")]
+    pub fn x11_connection(details: impl Into<String>) -> Self {
+        ErrorKind::X11Connection(details.into()).into()
+    }
+
+    /// Creates an error for invalid X11 screen.
+    #[cfg(feature = "x11")]
+    pub fn x11_invalid_screen(screen: i32) -> Self {
+        ErrorKind::X11InvalidScreen(screen).into()
+    }
+
+    /// Creates an error for Wayland connection failure.
+    #[cfg(feature = "wayland")]
+    pub fn wayland_connection_failed() -> Self {
+        ErrorKind::WaylandConnectionFailed.into()
+    }
+
+    /// Creates an error for Wayland event queue failure.
+    #[cfg(feature = "wayland")]
+    pub fn wayland_event_queue_failed(details: impl Into<String>) -> Self {
+        ErrorKind::WaylandEventQueueFailed(details.into()).into()
+    }
+
+    /// Creates an error for Wayland global bind failure.
+    #[cfg(feature = "wayland")]
+    pub fn wayland_global_bind_failed(details: impl Into<String>) -> Self {
+        ErrorKind::WaylandGlobalBindFailed(details.into()).into()
+    }
+
+    /// Creates an error for non-GNOME runtime.
+    #[cfg(feature = "gnome")]
+    pub fn not_gnome_runtime() -> Self {
+        ErrorKind::NotGnomeRuntime.into()
+    }
+
+    /// Creates an error for GNOME extension stopped.
+    #[cfg(feature = "gnome")]
+    pub fn gnome_extension_stopped() -> Self {
+        ErrorKind::GnomeExtensionStopped.into()
+    }
+
+    /// Creates an error for DBus response parse failure.
+    pub fn dbus_response_parse_failed(details: impl Into<String>) -> Self {
+        ErrorKind::DbusResponseParseFailed(details.into()).into()
+    }
+
+    /// Creates an error for DBus call failure.
+    pub fn dbus_call_failed(details: impl Into<String>) -> Self {
+        ErrorKind::DbusCallFailed(details.into()).into()
+    }
+
+    /// Creates an error for GNOME extension install failure.
+    pub fn gnome_extension_install_failed() -> Self {
+        ErrorKind::GnomeExtensionInstallFailed.into()
+    }
+
+    /// Creates an error for GNOME extension activate failure.
+    pub fn gnome_extension_activate_failed() -> Self {
+        ErrorKind::GnomeExtensionActivateFailed.into()
+    }
+
+    /// Creates an error for KWin script creation failure.
+    #[cfg(feature = "kde")]
+    pub fn kwin_script_creation_failed(details: impl Into<String>) -> Self {
+        ErrorKind::KwinScriptCreationFailed(details.into()).into()
+    }
+
+    /// Creates an error for KWin script start failure.
+    #[cfg(feature = "kde")]
+    pub fn kwin_script_start_failed() -> Self {
+        ErrorKind::KwinScriptStartFailed.into()
+    }
+
+    /// Creates an error for KWin version not found.
+    #[cfg(feature = "kde")]
+    pub fn kwin_version_not_found() -> Self {
+        ErrorKind::KwinVersionNotFound.into()
+    }
+
+    /// Creates an error for invalid KWin version.
+    #[cfg(feature = "kde")]
+    pub fn kwin_version_invalid(version: impl Into<String>) -> Self {
+        ErrorKind::KwinVersionInvalid(version.into()).into()
+    }
+
+    /// Creates an error for DBus interface failure.
+    pub fn dbus_interface_failed(details: impl Into<String>) -> Self {
+        ErrorKind::DbusInterfaceFailed(details.into()).into()
+    }
+
+    /// Creates an error for invalid temp path.
+    #[cfg(feature = "kde")]
+    pub fn invalid_temp_path() -> Self {
+        ErrorKind::InvalidTempPath.into()
+    }
+
+    /// Creates an error for OSAScript execution failure.
+    #[cfg(feature = "macos")]
+    pub fn osa_script_execution_failed(details: impl Into<String>) -> Self {
+        ErrorKind::OsaScriptExecutionFailed(details.into()).into()
+    }
+
+    /// Creates an error for OSAScript compilation failure.
+    #[cfg(feature = "macos")]
+    pub fn osa_script_compilation_failed(details: impl Into<String>) -> Self {
+        ErrorKind::OsaScriptCompilationFailed(details.into()).into()
+    }
+
+    /// Creates an error for no OSAScript result.
+    #[cfg(feature = "macos")]
+    pub fn osa_script_no_result() -> Self {
+        ErrorKind::OsaScriptNoResult.into()
+    }
+
+    /// Creates an error for OSAScript not returning a string.
+    #[cfg(feature = "macos")]
+    pub fn osa_script_not_string() -> Self {
+        ErrorKind::OsaScriptNotString.into()
+    }
+
+    /// Creates an error for JXA JSON parse failure.
+    #[cfg(feature = "macos")]
+    pub fn jxa_json_parse_failed(reason: impl Into<String>, payload: impl Into<String>) -> Self {
+        ErrorKind::JxaJsonParseFailed {
+            reason: reason.into(),
+            payload: payload.into(),
+        }
+        .into()
+    }
+
+    /// Creates an error for no app info loaded.
+    #[cfg(feature = "macos")]
+    pub fn no_app_info_loaded() -> Self {
+        ErrorKind::NoAppInfoLoaded.into()
+    }
+
+    /// Creates an error for OSA language not found.
+    #[cfg(feature = "macos")]
+    pub fn osa_language_not_found() -> Self {
+        ErrorKind::OsaLanguageNotFound.into()
+    }
+
+    /// Creates an error for macOS startup failure.
+    #[cfg(feature = "macos")]
+    pub fn macos_startup_failed(details: impl Into<String>) -> Self {
+        ErrorKind::MacosStartupFailed(details.into()).into()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
 //! Error types for the whatawhat-lib crate.
 //!
-//! This module provides a structured error type with an inner `ErrorKind` enum
-//! that categorizes different error conditions. The outer `Error` struct is
-//! designed for future extensibility (e.g., adding context, backtraces, etc.).
+//! This module provides a structured error type with nested `ErrorKind` enums
+//! that categorize different error conditions by domain and platform.
 
 use std::fmt;
 
@@ -51,8 +50,350 @@ impl From<ErrorKind> for Error {
     }
 }
 
-// Blanket From implementations for external error types.
-// These allow the `?` operator to convert external errors to our Error type directly.
+// ============================================================================
+// Top-level ErrorKind
+// ============================================================================
+
+/// Categorizes the different types of errors that can occur.
+#[derive(Debug, thiserror::Error)]
+pub enum ErrorKind {
+    /// No window manager was selected or available.
+    #[error("no window manager was selected or available")]
+    NoWindowManager,
+
+    /// The current display server should use X11 instead.
+    #[error("X11 should be used instead of the current backend")]
+    ShouldUseX11,
+
+    /// Window-related errors.
+    #[error(transparent)]
+    Window(#[from] WindowError),
+
+    /// Idle detection errors.
+    #[error(transparent)]
+    Idle(#[from] IdleError),
+
+    /// Platform-specific errors.
+    #[error(transparent)]
+    Platform(#[from] PlatformError),
+
+    /// I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON parsing error.
+    #[error("JSON parsing error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Integer parsing error.
+    #[error("integer parsing error: {0}")]
+    ParseInt(#[from] std::num::ParseIntError),
+
+    /// Environment variable error.
+    #[error("environment variable error: {0}")]
+    EnvVar(#[from] std::env::VarError),
+}
+
+// ============================================================================
+// Window Errors
+// ============================================================================
+
+/// Errors related to window operations.
+#[derive(Debug, thiserror::Error)]
+pub enum WindowError {
+    /// Failed to get the foreground window.
+    #[error("failed to get the foreground window")]
+    ForegroundNotFound,
+
+    /// Failed to get the active window.
+    #[error("failed to get the active window: {0}")]
+    ActiveNotFound(String),
+
+    /// The current window is unknown (no window has been activated yet).
+    #[error("the current window is unknown (no window has been activated yet)")]
+    CurrentUnknown,
+
+    /// A window was not found by its ID.
+    #[error("window not found by ID: {0}")]
+    NotFoundById(String),
+
+    /// Failed to get the window process ID.
+    #[error("failed to get the window process ID")]
+    ProcessIdNotFound,
+
+    /// Failed to get the process name.
+    #[error("failed to get the process name for the window")]
+    ProcessNameNotFound,
+}
+
+// ============================================================================
+// Idle Errors
+// ============================================================================
+
+/// Errors related to idle detection.
+#[derive(Debug, thiserror::Error)]
+pub enum IdleError {
+    /// Failed to retrieve user idle time.
+    #[error("failed to retrieve user idle time")]
+    RetrievalFailed,
+
+    /// Failed to deserialize idle time response.
+    #[error("failed to deserialize idle time response")]
+    DeserializationFailed,
+}
+
+// ============================================================================
+// Platform Errors
+// ============================================================================
+
+/// Platform-specific errors.
+#[derive(Debug, thiserror::Error)]
+pub enum PlatformError {
+    /// X11-specific error.
+    #[cfg(feature = "x11")]
+    #[error(transparent)]
+    X11(#[from] X11Error),
+
+    /// Wayland-specific error.
+    #[cfg(feature = "wayland")]
+    #[error(transparent)]
+    Wayland(#[from] WaylandError),
+
+    /// GNOME-specific error.
+    #[cfg(feature = "gnome")]
+    #[error(transparent)]
+    Gnome(#[from] GnomeError),
+
+    /// KDE-specific error.
+    #[cfg(feature = "kde")]
+    #[error(transparent)]
+    Kde(#[from] KdeError),
+
+    /// macOS-specific error.
+    #[cfg(feature = "macos")]
+    #[error(transparent)]
+    Macos(#[from] MacosError),
+
+    /// Windows-specific error.
+    #[cfg(feature = "win")]
+    #[error(transparent)]
+    Windows(#[from] WindowsError),
+
+    /// DBus-related error (shared by GNOME and KDE).
+    #[cfg(any(feature = "gnome", feature = "kde"))]
+    #[error(transparent)]
+    Dbus(#[from] DbusError),
+}
+
+// ============================================================================
+// X11 Errors
+// ============================================================================
+
+/// X11-specific errors.
+#[cfg(feature = "x11")]
+#[derive(Debug, thiserror::Error)]
+pub enum X11Error {
+    /// Invalid X11 screen configuration.
+    #[error("invalid X11 screen: preferred screen is negative ({0})")]
+    InvalidScreen(i32),
+
+    /// X11 connection error (string description).
+    #[error("X11 connection error: {0}")]
+    Connection(String),
+
+    /// XCB protocol error.
+    #[error("XCB protocol error: {0}")]
+    Protocol(#[from] xcb::Error),
+
+    /// XCB connection error.
+    #[error("XCB connection error: {0}")]
+    ConnError(#[from] xcb::ConnError),
+}
+
+// ============================================================================
+// Wayland Errors
+// ============================================================================
+
+/// Wayland-specific errors.
+#[cfg(feature = "wayland")]
+#[derive(Debug, thiserror::Error)]
+pub enum WaylandError {
+    /// Failed to connect to the Wayland compositor.
+    #[error("failed to connect to the Wayland compositor")]
+    ConnectionFailed,
+
+    /// Wayland event queue processing failed.
+    #[error("Wayland event queue processing failed: {0}")]
+    EventQueueFailed(String),
+
+    /// Wayland backend error.
+    #[error("Wayland backend error: {0}")]
+    Backend(#[from] wayland_client::backend::WaylandError),
+
+    /// Wayland connection error.
+    #[error("Wayland connection error: {0}")]
+    Connect(#[from] wayland_client::ConnectError),
+
+    /// Wayland dispatch error.
+    #[error("Wayland dispatch error: {0}")]
+    Dispatch(#[from] wayland_client::DispatchError),
+
+    /// Wayland global error.
+    #[error("Wayland global error: {0}")]
+    Global(#[from] wayland_client::globals::GlobalError),
+
+    /// Wayland bind error.
+    #[error("Wayland bind error: {0}")]
+    Bind(#[from] wayland_client::globals::BindError),
+}
+
+// ============================================================================
+// DBus Errors (shared by GNOME and KDE)
+// ============================================================================
+
+/// DBus-related errors.
+#[cfg(any(feature = "gnome", feature = "kde"))]
+#[derive(Debug, thiserror::Error)]
+pub enum DbusError {
+    /// Failed to parse DBus response.
+    #[error("failed to parse DBus response: {0}")]
+    ResponseParseFailed(String),
+
+    /// DBus call failed.
+    #[error("DBus call failed: {0}")]
+    CallFailed(String),
+
+    /// Failed to get idle time from DBus.
+    #[error("failed to get idle time from DBus: {0}")]
+    IdleTimeFailed(String),
+
+    /// Failed to run DBus interface.
+    #[error("failed to run DBus interface: {0}")]
+    InterfaceFailed(String),
+
+    /// ZBus error.
+    #[error("ZBus error: {0}")]
+    Zbus(#[from] zbus::Error),
+}
+
+// ============================================================================
+// GNOME Errors
+// ============================================================================
+
+/// GNOME-specific errors.
+#[cfg(feature = "gnome")]
+#[derive(Debug, thiserror::Error)]
+pub enum GnomeError {
+    /// The runtime doesn't appear to be GNOME.
+    #[error("the runtime doesn't appear to be GNOME")]
+    NotGnomeRuntime,
+
+    /// The GNOME extension appears to have stopped.
+    #[error("the GNOME extension appears to have stopped responding")]
+    ExtensionStopped,
+
+    /// Failed to install GNOME extension.
+    #[error("failed to install GNOME extension")]
+    ExtensionInstallFailed,
+
+    /// Failed to activate GNOME extension.
+    #[error("failed to activate GNOME extension")]
+    ExtensionActivateFailed,
+}
+
+// ============================================================================
+// KDE Errors
+// ============================================================================
+
+/// KDE-specific errors.
+#[cfg(feature = "kde")]
+#[derive(Debug, thiserror::Error)]
+pub enum KdeError {
+    /// Failed to create KWin script.
+    #[error("failed to create KWin script: {0}")]
+    ScriptCreationFailed(String),
+
+    /// Failed to start KWin script.
+    #[error("failed to start KWin script")]
+    ScriptStartFailed,
+
+    /// KWin version not found.
+    #[error("KWin version not found in support information")]
+    VersionNotFound,
+
+    /// KWin version is invalid.
+    #[error("KWin version is invalid: {0}")]
+    VersionInvalid(String),
+
+    /// Temporary file path is not valid UTF-8.
+    #[error("temporary file path is not valid UTF-8")]
+    InvalidTempPath,
+}
+
+// ============================================================================
+// macOS Errors
+// ============================================================================
+
+/// macOS-specific errors.
+#[cfg(feature = "macos")]
+#[derive(Debug, thiserror::Error)]
+pub enum MacosError {
+    /// OSAScript execution error.
+    #[error("OSAScript execution error: {0}")]
+    ScriptExecutionFailed(String),
+
+    /// OSAScript compilation error.
+    #[error("OSAScript compilation error: {0}")]
+    ScriptCompilationFailed(String),
+
+    /// No result from OSAScript execution.
+    #[error("no result returned from OSAScript execution")]
+    ScriptNoResult,
+
+    /// OSAScript did not return a string value.
+    #[error("OSAScript did not return a string value")]
+    ScriptNotString,
+
+    /// Failed to parse JXA JSON output.
+    #[error("failed to parse JXA JSON: {reason}; payload: {payload}")]
+    JxaJsonParseFailed { reason: String, payload: String },
+
+    /// No app info was loaded.
+    #[error("no app info was loaded from the background process")]
+    NoAppInfoLoaded,
+
+    /// Failed to get JavaScript OSALanguage.
+    #[error("failed to get JavaScript OSALanguage")]
+    LanguageNotFound,
+
+    /// macOS permissions may be denied (startup error).
+    #[error("macOS startup error (permissions may be denied): {0}")]
+    StartupFailed(String),
+}
+
+// ============================================================================
+// Windows Errors
+// ============================================================================
+
+/// Windows-specific errors.
+#[cfg(feature = "win")]
+#[derive(Debug, thiserror::Error)]
+pub enum WindowsError {
+    /// Windows API error.
+    #[error("Windows API error: {0}")]
+    Api(#[from] windows::core::Error),
+}
+
+// ============================================================================
+// Result type alias
+// ============================================================================
+
+/// A specialized Result type for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+// ============================================================================
+// From implementations for Error
+// ============================================================================
 
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
@@ -78,517 +419,320 @@ impl From<std::env::VarError> for Error {
     }
 }
 
+impl From<WindowError> for Error {
+    fn from(err: WindowError) -> Self {
+        ErrorKind::Window(err).into()
+    }
+}
+
+impl From<IdleError> for Error {
+    fn from(err: IdleError) -> Self {
+        ErrorKind::Idle(err).into()
+    }
+}
+
+impl From<PlatformError> for Error {
+    fn from(err: PlatformError) -> Self {
+        ErrorKind::Platform(err).into()
+    }
+}
+
+#[cfg(feature = "x11")]
+impl From<X11Error> for Error {
+    fn from(err: X11Error) -> Self {
+        PlatformError::X11(err).into()
+    }
+}
+
 #[cfg(feature = "x11")]
 impl From<xcb::Error> for Error {
     fn from(err: xcb::Error) -> Self {
-        ErrorKind::Xcb(err).into()
+        X11Error::Protocol(err).into()
     }
 }
 
 #[cfg(feature = "x11")]
 impl From<xcb::ConnError> for Error {
     fn from(err: xcb::ConnError) -> Self {
-        ErrorKind::XcbConnection(err).into()
+        X11Error::ConnError(err).into()
     }
 }
 
-#[cfg(any(feature = "gnome", feature = "kde"))]
-impl From<zbus::Error> for Error {
-    fn from(err: zbus::Error) -> Self {
-        ErrorKind::Zbus(err).into()
+#[cfg(feature = "wayland")]
+impl From<WaylandError> for Error {
+    fn from(err: WaylandError) -> Self {
+        PlatformError::Wayland(err).into()
     }
 }
 
 #[cfg(feature = "wayland")]
 impl From<wayland_client::backend::WaylandError> for Error {
     fn from(err: wayland_client::backend::WaylandError) -> Self {
-        ErrorKind::WaylandBackend(err).into()
+        WaylandError::Backend(err).into()
     }
 }
 
 #[cfg(feature = "wayland")]
 impl From<wayland_client::ConnectError> for Error {
     fn from(err: wayland_client::ConnectError) -> Self {
-        ErrorKind::WaylandConnect(err).into()
+        WaylandError::Connect(err).into()
     }
 }
 
 #[cfg(feature = "wayland")]
 impl From<wayland_client::DispatchError> for Error {
     fn from(err: wayland_client::DispatchError) -> Self {
-        ErrorKind::WaylandDispatch(err).into()
+        WaylandError::Dispatch(err).into()
     }
 }
 
 #[cfg(feature = "wayland")]
 impl From<wayland_client::globals::GlobalError> for Error {
     fn from(err: wayland_client::globals::GlobalError) -> Self {
-        ErrorKind::WaylandGlobal(err).into()
+        WaylandError::Global(err).into()
     }
 }
 
 #[cfg(feature = "wayland")]
 impl From<wayland_client::globals::BindError> for Error {
     fn from(err: wayland_client::globals::BindError) -> Self {
-        ErrorKind::WaylandBind(err).into()
+        WaylandError::Bind(err).into()
+    }
+}
+
+#[cfg(any(feature = "gnome", feature = "kde"))]
+impl From<DbusError> for Error {
+    fn from(err: DbusError) -> Self {
+        PlatformError::Dbus(err).into()
+    }
+}
+
+#[cfg(any(feature = "gnome", feature = "kde"))]
+impl From<zbus::Error> for Error {
+    fn from(err: zbus::Error) -> Self {
+        DbusError::Zbus(err).into()
+    }
+}
+
+#[cfg(feature = "gnome")]
+impl From<GnomeError> for Error {
+    fn from(err: GnomeError) -> Self {
+        PlatformError::Gnome(err).into()
+    }
+}
+
+#[cfg(feature = "kde")]
+impl From<KdeError> for Error {
+    fn from(err: KdeError) -> Self {
+        PlatformError::Kde(err).into()
+    }
+}
+
+#[cfg(feature = "macos")]
+impl From<MacosError> for Error {
+    fn from(err: MacosError) -> Self {
+        PlatformError::Macos(err).into()
+    }
+}
+
+#[cfg(feature = "win")]
+impl From<WindowsError> for Error {
+    fn from(err: WindowsError) -> Self {
+        PlatformError::Windows(err).into()
     }
 }
 
 #[cfg(feature = "win")]
 impl From<windows::core::Error> for Error {
     fn from(err: windows::core::Error) -> Self {
-        ErrorKind::Windows(err).into()
+        WindowsError::Api(err).into()
     }
 }
 
-/// Categorizes the different types of errors that can occur.
-#[derive(Debug, thiserror::Error)]
-pub enum ErrorKind {
-    // ========================
-    // General / Initialization
-    // ========================
-    /// No window manager was selected or available.
-    #[error("no window manager was selected or available")]
-    NoWindowManager,
-
-    /// The current display server should use X11 instead.
-    #[error("X11 should be used instead of the current backend")]
-    ShouldUseX11,
-
-    // ========================
-    // Window Operations
-    // ========================
-    /// Failed to get the foreground window.
-    #[error("failed to get the foreground window")]
-    ForegroundWindowNotFound,
-
-    /// Failed to get the active window.
-    #[error("failed to get the active window: {0}")]
-    ActiveWindowNotFound(String),
-
-    /// The current window is unknown (no window has been activated yet).
-    #[error("the current window is unknown (no window has been activated yet)")]
-    CurrentWindowUnknown,
-
-    /// A window was not found by its ID.
-    #[error("window not found by ID: {0}")]
-    WindowNotFoundById(String),
-
-    /// Failed to get the window process ID.
-    #[error("failed to get the window process ID")]
-    ProcessIdNotFound,
-
-    /// Failed to get the process name.
-    #[error("failed to get the process name for the window")]
-    ProcessNameNotFound,
-
-    // ========================
-    // Idle Detection
-    // ========================
-    /// Failed to retrieve user idle time.
-    #[error("failed to retrieve user idle time")]
-    IdleTimeRetrievalFailed,
-
-    /// Failed to get idle time from DBus.
-    #[error("failed to get idle time from DBus: {0}")]
-    DbusIdleTimeFailed(String),
-
-    /// Failed to deserialize idle time.
-    #[error("failed to deserialize idle time response")]
-    IdleTimeDeserializationFailed,
-
-    // ========================
-    // X11 Specific
-    // ========================
-    /// X11 connection error.
-    #[error("X11 connection error: {0}")]
-    X11Connection(String),
-
-    /// Invalid X11 screen configuration.
-    #[error("invalid X11 screen: preferred screen is negative ({0})")]
-    X11InvalidScreen(i32),
-
-    // ========================
-    // Wayland Specific
-    // ========================
-    /// Failed to connect to the Wayland compositor.
-    #[error("failed to connect to the Wayland compositor")]
-    WaylandConnectionFailed,
-
-    /// Wayland event queue processing failed.
-    #[error("Wayland event queue processing failed: {0}")]
-    WaylandEventQueueFailed(String),
-
-    /// Failed to bind a Wayland global.
-    #[error("failed to bind Wayland global: {0}")]
-    WaylandGlobalBindFailed(String),
-
-    // ========================
-    // GNOME Specific
-    // ========================
-    /// The runtime doesn't appear to be GNOME.
-    #[error("the runtime doesn't appear to be GNOME")]
-    NotGnomeRuntime,
-
-    /// The GNOME extension appears to have stopped.
-    #[error("the GNOME extension appears to have stopped responding")]
-    GnomeExtensionStopped,
-
-    /// Failed to parse DBus response.
-    #[error("failed to parse DBus response: {0}")]
-    DbusResponseParseFailed(String),
-
-    /// DBus call failed.
-    #[error("DBus call failed: {0}")]
-    DbusCallFailed(String),
-
-    /// Failed to install GNOME extension.
-    #[error("failed to install GNOME extension")]
-    GnomeExtensionInstallFailed,
-
-    /// Failed to activate GNOME extension.
-    #[error("failed to activate GNOME extension")]
-    GnomeExtensionActivateFailed,
-
-    // ========================
-    // KDE Specific
-    // ========================
-    /// Failed to create KWin script.
-    #[error("failed to create KWin script: {0}")]
-    KwinScriptCreationFailed(String),
-
-    /// Failed to start KWin script.
-    #[error("failed to start KWin script")]
-    KwinScriptStartFailed,
-
-    /// KWin version not found.
-    #[error("KWin version not found in support information")]
-    KwinVersionNotFound,
-
-    /// KWin version is invalid.
-    #[error("KWin version is invalid: {0}")]
-    KwinVersionInvalid(String),
-
-    /// Failed to run DBus interface.
-    #[error("failed to run DBus interface: {0}")]
-    DbusInterfaceFailed(String),
-
-    /// Temporary file path is not valid UTF-8.
-    #[error("temporary file path is not valid UTF-8")]
-    InvalidTempPath,
-
-    // ========================
-    // macOS Specific
-    // ========================
-    /// OSAScript execution error.
-    #[error("OSAScript execution error: {0}")]
-    OsaScriptExecutionFailed(String),
-
-    /// OSAScript compilation error.
-    #[error("OSAScript compilation error: {0}")]
-    OsaScriptCompilationFailed(String),
-
-    /// No result from OSAScript execution.
-    #[error("no result returned from OSAScript execution")]
-    OsaScriptNoResult,
-
-    /// OSAScript did not return a string value.
-    #[error("OSAScript did not return a string value")]
-    OsaScriptNotString,
-
-    /// Failed to parse JXA JSON output.
-    #[error("failed to parse JXA JSON: {reason}; payload: {payload}")]
-    JxaJsonParseFailed { reason: String, payload: String },
-
-    /// No app info was loaded.
-    #[error("no app info was loaded from the background process")]
-    NoAppInfoLoaded,
-
-    /// Failed to get JavaScript OSALanguage.
-    #[error("failed to get JavaScript OSALanguage")]
-    OsaLanguageNotFound,
-
-    /// macOS permissions may be denied (startup error).
-    #[error("macOS startup error (permissions may be denied): {0}")]
-    MacosStartupFailed(String),
-
-    // ========================
-    // I/O and System Errors
-    // ========================
-    /// I/O error.
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
-
-    /// JSON parsing error.
-    #[error("JSON parsing error: {0}")]
-    Json(#[from] serde_json::Error),
-
-    /// Integer parsing error.
-    #[error("integer parsing error: {0}")]
-    ParseInt(#[from] std::num::ParseIntError),
-
-    /// Environment variable error.
-    #[error("environment variable error: {0}")]
-    EnvVar(#[from] std::env::VarError),
-
-    // ========================
-    // External Library Errors
-    // ========================
-    /// XCB (X11) protocol error.
-    #[cfg(feature = "x11")]
-    #[error("XCB protocol error: {0}")]
-    Xcb(#[from] xcb::Error),
-
-    /// XCB connection error.
-    #[cfg(feature = "x11")]
-    #[error("XCB connection error: {0}")]
-    XcbConnection(#[from] xcb::ConnError),
-
-    /// ZBus (DBus) error.
-    #[cfg(any(feature = "gnome", feature = "kde"))]
-    #[error("DBus error: {0}")]
-    Zbus(#[from] zbus::Error),
-
-    /// Wayland backend error.
-    #[cfg(feature = "wayland")]
-    #[error("Wayland backend error: {0}")]
-    WaylandBackend(#[from] wayland_client::backend::WaylandError),
-
-    /// Wayland connection error.
-    #[cfg(feature = "wayland")]
-    #[error("Wayland connection error: {0}")]
-    WaylandConnect(#[from] wayland_client::ConnectError),
-
-    /// Wayland dispatch error.
-    #[cfg(feature = "wayland")]
-    #[error("Wayland dispatch error: {0}")]
-    WaylandDispatch(#[from] wayland_client::DispatchError),
-
-    /// Wayland global error.
-    #[cfg(feature = "wayland")]
-    #[error("Wayland global error: {0}")]
-    WaylandGlobal(#[from] wayland_client::globals::GlobalError),
-
-    /// Wayland bind error.
-    #[cfg(feature = "wayland")]
-    #[error("Wayland bind error: {0}")]
-    WaylandBind(#[from] wayland_client::globals::BindError),
-
-    /// Windows API error.
-    #[cfg(feature = "win")]
-    #[error("Windows API error: {0}")]
-    Windows(#[from] windows::core::Error),
-}
-
-/// A specialized Result type for this crate.
-pub type Result<T> = std::result::Result<T, Error>;
-
-// ========================
-// Convenience constructors
-// ========================
+// ============================================================================
+// Convenience constructors on Error
+// ============================================================================
 
 impl Error {
-    /// Creates an error for when no window manager is available.
+    // General
     pub fn no_window_manager() -> Self {
         ErrorKind::NoWindowManager.into()
     }
 
-    /// Creates an error indicating X11 should be used instead.
     pub fn should_use_x11() -> Self {
         ErrorKind::ShouldUseX11.into()
     }
 
-    /// Creates an error for when the foreground window cannot be found.
+    // Window errors
     pub fn foreground_window_not_found() -> Self {
-        ErrorKind::ForegroundWindowNotFound.into()
+        WindowError::ForegroundNotFound.into()
     }
 
-    /// Creates an error for when the active window cannot be found.
     pub fn active_window_not_found(details: impl Into<String>) -> Self {
-        ErrorKind::ActiveWindowNotFound(details.into()).into()
+        WindowError::ActiveNotFound(details.into()).into()
     }
 
-    /// Creates an error for when the current window is unknown.
     pub fn current_window_unknown() -> Self {
-        ErrorKind::CurrentWindowUnknown.into()
+        WindowError::CurrentUnknown.into()
     }
 
-    /// Creates an error for when a window is not found by ID.
     pub fn window_not_found_by_id(id: impl Into<String>) -> Self {
-        ErrorKind::WindowNotFoundById(id.into()).into()
+        WindowError::NotFoundById(id.into()).into()
     }
 
-    /// Creates an error for when the process ID cannot be found.
     pub fn process_id_not_found() -> Self {
-        ErrorKind::ProcessIdNotFound.into()
+        WindowError::ProcessIdNotFound.into()
     }
 
-    /// Creates an error for when the process name cannot be found.
     pub fn process_name_not_found() -> Self {
-        ErrorKind::ProcessNameNotFound.into()
+        WindowError::ProcessNameNotFound.into()
     }
 
-    /// Creates an error for idle time retrieval failure.
+    // Idle errors
     pub fn idle_time_retrieval_failed() -> Self {
-        ErrorKind::IdleTimeRetrievalFailed.into()
+        IdleError::RetrievalFailed.into()
     }
 
-    /// Creates an error for DBus idle time failure.
-    pub fn dbus_idle_time_failed(details: impl Into<String>) -> Self {
-        ErrorKind::DbusIdleTimeFailed(details.into()).into()
-    }
-
-    /// Creates an error for idle time deserialization failure.
     pub fn idle_time_deserialization_failed() -> Self {
-        ErrorKind::IdleTimeDeserializationFailed.into()
+        IdleError::DeserializationFailed.into()
     }
 
-    /// Creates an error for X11 connection issues.
-    #[cfg(feature = "x11")]
-    pub fn x11_connection(details: impl Into<String>) -> Self {
-        ErrorKind::X11Connection(details.into()).into()
-    }
-
-    /// Creates an error for invalid X11 screen.
+    // X11 errors
     #[cfg(feature = "x11")]
     pub fn x11_invalid_screen(screen: i32) -> Self {
-        ErrorKind::X11InvalidScreen(screen).into()
+        X11Error::InvalidScreen(screen).into()
     }
 
-    /// Creates an error for Wayland connection failure.
+    #[cfg(feature = "x11")]
+    pub fn x11_connection(details: impl Into<String>) -> Self {
+        X11Error::Connection(details.into()).into()
+    }
+
+    // Wayland errors
     #[cfg(feature = "wayland")]
     pub fn wayland_connection_failed() -> Self {
-        ErrorKind::WaylandConnectionFailed.into()
+        WaylandError::ConnectionFailed.into()
     }
 
-    /// Creates an error for Wayland event queue failure.
     #[cfg(feature = "wayland")]
     pub fn wayland_event_queue_failed(details: impl Into<String>) -> Self {
-        ErrorKind::WaylandEventQueueFailed(details.into()).into()
+        WaylandError::EventQueueFailed(details.into()).into()
     }
 
-    /// Creates an error for Wayland global bind failure.
-    #[cfg(feature = "wayland")]
-    pub fn wayland_global_bind_failed(details: impl Into<String>) -> Self {
-        ErrorKind::WaylandGlobalBindFailed(details.into()).into()
+    // DBus errors
+    #[cfg(any(feature = "gnome", feature = "kde"))]
+    pub fn dbus_response_parse_failed(details: impl Into<String>) -> Self {
+        DbusError::ResponseParseFailed(details.into()).into()
     }
 
-    /// Creates an error for non-GNOME runtime.
+    #[cfg(any(feature = "gnome", feature = "kde"))]
+    pub fn dbus_call_failed(details: impl Into<String>) -> Self {
+        DbusError::CallFailed(details.into()).into()
+    }
+
+    #[cfg(any(feature = "gnome", feature = "kde"))]
+    pub fn dbus_idle_time_failed(details: impl Into<String>) -> Self {
+        DbusError::IdleTimeFailed(details.into()).into()
+    }
+
+    #[cfg(any(feature = "gnome", feature = "kde"))]
+    pub fn dbus_interface_failed(details: impl Into<String>) -> Self {
+        DbusError::InterfaceFailed(details.into()).into()
+    }
+
+    // GNOME errors
     #[cfg(feature = "gnome")]
     pub fn not_gnome_runtime() -> Self {
-        ErrorKind::NotGnomeRuntime.into()
+        GnomeError::NotGnomeRuntime.into()
     }
 
-    /// Creates an error for GNOME extension stopped.
     #[cfg(feature = "gnome")]
     pub fn gnome_extension_stopped() -> Self {
-        ErrorKind::GnomeExtensionStopped.into()
+        GnomeError::ExtensionStopped.into()
     }
 
-    /// Creates an error for DBus response parse failure.
-    pub fn dbus_response_parse_failed(details: impl Into<String>) -> Self {
-        ErrorKind::DbusResponseParseFailed(details.into()).into()
-    }
-
-    /// Creates an error for DBus call failure.
-    pub fn dbus_call_failed(details: impl Into<String>) -> Self {
-        ErrorKind::DbusCallFailed(details.into()).into()
-    }
-
-    /// Creates an error for GNOME extension install failure.
     pub fn gnome_extension_install_failed() -> Self {
-        ErrorKind::GnomeExtensionInstallFailed.into()
+        #[cfg(feature = "gnome")]
+        return GnomeError::ExtensionInstallFailed.into();
+        #[cfg(not(feature = "gnome"))]
+        panic!("gnome feature not enabled")
     }
 
-    /// Creates an error for GNOME extension activate failure.
     pub fn gnome_extension_activate_failed() -> Self {
-        ErrorKind::GnomeExtensionActivateFailed.into()
+        #[cfg(feature = "gnome")]
+        return GnomeError::ExtensionActivateFailed.into();
+        #[cfg(not(feature = "gnome"))]
+        panic!("gnome feature not enabled")
     }
 
-    /// Creates an error for KWin script creation failure.
+    // KDE errors
     #[cfg(feature = "kde")]
     pub fn kwin_script_creation_failed(details: impl Into<String>) -> Self {
-        ErrorKind::KwinScriptCreationFailed(details.into()).into()
+        KdeError::ScriptCreationFailed(details.into()).into()
     }
 
-    /// Creates an error for KWin script start failure.
     #[cfg(feature = "kde")]
     pub fn kwin_script_start_failed() -> Self {
-        ErrorKind::KwinScriptStartFailed.into()
+        KdeError::ScriptStartFailed.into()
     }
 
-    /// Creates an error for KWin version not found.
     #[cfg(feature = "kde")]
     pub fn kwin_version_not_found() -> Self {
-        ErrorKind::KwinVersionNotFound.into()
+        KdeError::VersionNotFound.into()
     }
 
-    /// Creates an error for invalid KWin version.
     #[cfg(feature = "kde")]
     pub fn kwin_version_invalid(version: impl Into<String>) -> Self {
-        ErrorKind::KwinVersionInvalid(version.into()).into()
+        KdeError::VersionInvalid(version.into()).into()
     }
 
-    /// Creates an error for DBus interface failure.
-    pub fn dbus_interface_failed(details: impl Into<String>) -> Self {
-        ErrorKind::DbusInterfaceFailed(details.into()).into()
-    }
-
-    /// Creates an error for invalid temp path.
     #[cfg(feature = "kde")]
     pub fn invalid_temp_path() -> Self {
-        ErrorKind::InvalidTempPath.into()
+        KdeError::InvalidTempPath.into()
     }
 
-    /// Creates an error for OSAScript execution failure.
+    // macOS errors
     #[cfg(feature = "macos")]
     pub fn osa_script_execution_failed(details: impl Into<String>) -> Self {
-        ErrorKind::OsaScriptExecutionFailed(details.into()).into()
+        MacosError::ScriptExecutionFailed(details.into()).into()
     }
 
-    /// Creates an error for OSAScript compilation failure.
     #[cfg(feature = "macos")]
     pub fn osa_script_compilation_failed(details: impl Into<String>) -> Self {
-        ErrorKind::OsaScriptCompilationFailed(details.into()).into()
+        MacosError::ScriptCompilationFailed(details.into()).into()
     }
 
-    /// Creates an error for no OSAScript result.
     #[cfg(feature = "macos")]
     pub fn osa_script_no_result() -> Self {
-        ErrorKind::OsaScriptNoResult.into()
+        MacosError::ScriptNoResult.into()
     }
 
-    /// Creates an error for OSAScript not returning a string.
     #[cfg(feature = "macos")]
     pub fn osa_script_not_string() -> Self {
-        ErrorKind::OsaScriptNotString.into()
+        MacosError::ScriptNotString.into()
     }
 
-    /// Creates an error for JXA JSON parse failure.
     #[cfg(feature = "macos")]
     pub fn jxa_json_parse_failed(reason: impl Into<String>, payload: impl Into<String>) -> Self {
-        ErrorKind::JxaJsonParseFailed {
+        MacosError::JxaJsonParseFailed {
             reason: reason.into(),
             payload: payload.into(),
         }
         .into()
     }
 
-    /// Creates an error for no app info loaded.
     #[cfg(feature = "macos")]
     pub fn no_app_info_loaded() -> Self {
-        ErrorKind::NoAppInfoLoaded.into()
+        MacosError::NoAppInfoLoaded.into()
     }
 
-    /// Creates an error for OSA language not found.
     #[cfg(feature = "macos")]
     pub fn osa_language_not_found() -> Self {
-        ErrorKind::OsaLanguageNotFound.into()
+        MacosError::LanguageNotFound.into()
     }
 
-    /// Creates an error for macOS startup failure.
     #[cfg(feature = "macos")]
     pub fn macos_startup_failed(details: impl Into<String>) -> Self {
-        ErrorKind::MacosStartupFailed(details.into()).into()
+        MacosError::StartupFailed(details.into()).into()
     }
 }

--- a/src/gnome.rs
+++ b/src/gnome.rs
@@ -1,12 +1,11 @@
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow};
 use serde::Deserialize;
 use tracing::{debug, trace};
 use zbus::blocking::Connection;
 
 use crate::{
-    ActiveWindowData, WindowManager,
+    ActiveWindowData, Error, Result, WindowManager,
     config::WatcherConfig,
     linux_desktop::{DesktopInfo, LinuxDesktopInfo},
     simple_cache::SimpleCache,
@@ -30,7 +29,7 @@ struct WindowData {
 }
 
 impl GnomeWindowWatcher {
-    fn get_window_data(&self) -> anyhow::Result<WindowData> {
+    fn get_window_data(&self) -> Result<WindowData> {
         let call_response = self.dbus_connection.call_method(
             Some(self.gnome_dbus_config.window_service.as_str()),
             self.gnome_dbus_config.window_path.as_str(),
@@ -44,9 +43,11 @@ impl GnomeWindowWatcher {
                 let json: String = json
                     .body()
                     .deserialize()
-                    .with_context(|| "DBus interface cannot be parsed as string")?;
-                serde_json::from_str(&json).with_context(|| {
-                    format!("DBus interface org.gnome.shell.extensions.FocusedWindow returned wrong JSON: {json}")
+                    .map_err(|_| Error::dbus_response_parse_failed("DBus interface cannot be parsed as string"))?;
+                serde_json::from_str(&json).map_err(|_| {
+                    Error::dbus_response_parse_failed(format!(
+                        "DBus interface org.gnome.shell.extensions.FocusedWindow returned wrong JSON: {json}"
+                    ))
                 })
             }
             Err(e) => {
@@ -69,10 +70,10 @@ impl GnomeWindowWatcher {
             &(),
         );
         let result = call_response
-            .with_context(|| "Failed to get idle time")?
+            .map_err(|e| Error::dbus_idle_time_failed(e.to_string()))?
             .body()
             .deserialize::<u64>()
-            .with_context(|| "Failed to deserialize idle time")?;
+            .map_err(|_| Error::idle_time_deserialization_failed())?;
         Ok(result)
     }
 }
@@ -94,21 +95,23 @@ impl GnomeWindowWatcher {
         };
 
         if is_x11() {
-            return Err(anyhow!("X11 should be tried instead"));
+            return Err(Error::should_use_x11());
         }
 
         if !is_gnome() {
-            return Err(anyhow!("The runtime doesn't seem to be Gnome"));
+            return Err(Error::not_gnome_runtime());
         }
 
         debug!("Gnome Wayland detected");
 
-        let mut watcher = Err(anyhow::anyhow!(""));
+        let mut watcher: Result<Self> = Err(Error::dbus_call_failed("failed to initialize GNOME watcher after retries"));
         for _ in 0..3 {
             watcher = loader();
             if let Err(e) = &watcher {
                 debug!("Failed to load Gnome Wayland watcher: {e}");
                 std::thread::sleep(std::time::Duration::from_secs(3));
+            } else {
+                break;
             }
         }
         watcher
@@ -121,7 +124,7 @@ impl WindowManager for GnomeWindowWatcher {
         if let Err(e) = data {
             if e.to_string().contains("Object does not exist at path") {
                 trace!("The extension seems to have stopped");
-                return Err(anyhow::anyhow!("The extension seems to have stopped"));
+                return Err(Error::gnome_extension_stopped());
             }
             return Err(e);
         }

--- a/src/gnome_install.rs
+++ b/src/gnome_install.rs
@@ -1,13 +1,13 @@
 use std::{path::Path, process::Command};
 
-use anyhow::{Context as _, Result};
+use crate::{Error, Result};
 
 pub fn install_gnome_extension(path: &Path) -> Result<()> {
     Command::new("gnome-extensions")
         .arg("install")
         .arg(path)
         .status()
-        .with_context(|| "Failed to install gnome extension")?;
+        .map_err(|_| Error::gnome_extension_install_failed())?;
 
     Ok(())
 }
@@ -19,7 +19,7 @@ pub fn activate_gnome_extension() -> Result<()> {
         .arg("enable")
         .arg(EXTENSION_UUID)
         .status()
-        .with_context(|| "Failed to activate gnome extension")?;
+        .map_err(|_| Error::gnome_extension_activate_failed())?;
 
     Ok(())
 }

--- a/src/idle.rs
+++ b/src/idle.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use chrono::{DateTime, TimeDelta, Utc};
 use std::cmp::max;
 use tracing::debug;
@@ -59,7 +60,7 @@ impl Tracker {
         &mut self,
         now: DateTime<Utc>,
         seconds_since_input: u32,
-    ) -> anyhow::Result<Status> {
+    ) -> Result<Status> {
         let time_since_input = TimeDelta::seconds(i64::from(seconds_since_input));
 
         self.last_input_time = now - time_since_input;
@@ -79,7 +80,7 @@ impl Tracker {
         Ok(self.get_status(now))
     }
 
-    pub fn get_reactive(&mut self, now: DateTime<Utc>) -> anyhow::Result<Status> {
+    pub fn get_reactive(&mut self, now: DateTime<Utc>) -> Result<Status> {
         if !self.is_idle {
             self.last_input_time = max(self.last_input_time, now - self.idle_timeout);
 

--- a/src/kde.rs
+++ b/src/kde.rs
@@ -7,8 +7,7 @@ use crate::idle::Status;
 use crate::linux_desktop::{DesktopInfo, LinuxDesktopInfo};
 use crate::simple_cache::SimpleCache;
 use crate::wayland_idle::IdleWatcherRunner;
-use crate::{ActiveWindowData, WindowManager, config::WatcherConfig};
-use anyhow::{Context, Result, anyhow};
+use crate::{ActiveWindowData, Error, Result, WindowManager, config::WatcherConfig};
 use std::env::{self, temp_dir};
 use std::path::Path;
 use std::sync::Arc;
@@ -33,9 +32,10 @@ impl KWinScript {
         }
     }
 
-    fn load(&mut self) -> anyhow::Result<()> {
+    fn load(&mut self) -> Result<()> {
         let path = temp_dir().join("whatawhat-lib.js");
-        std::fs::write(&path, KWIN_SCRIPT).with_context(|| "Failed to create kwin script")?;
+        std::fs::write(&path, KWIN_SCRIPT)
+            .map_err(|e| Error::kwin_script_creation_failed(e.to_string()))?;
 
         let number = self.get_registered_number(&path)?;
         let result = self.start(number);
@@ -45,7 +45,7 @@ impl KWinScript {
         result
     }
 
-    fn is_loaded(&self) -> anyhow::Result<bool> {
+    fn is_loaded(&self) -> Result<bool> {
         self.dbus_connection
             .call_method(
                 Some("org.kde.KWin"),
@@ -56,13 +56,13 @@ impl KWinScript {
             )?
             .body()
             .deserialize()
-            .map_err(std::convert::Into::into)
+            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))
     }
 
-    fn get_registered_number(&self, path: &Path) -> anyhow::Result<i32> {
+    fn get_registered_number(&self, path: &Path) -> Result<i32> {
         let temp_path = path
             .to_str()
-            .ok_or(anyhow!("Temporary file path is not valid"))?;
+            .ok_or_else(Error::invalid_temp_path)?;
 
         self.dbus_connection
             .call_method(
@@ -75,10 +75,10 @@ impl KWinScript {
             )?
             .body()
             .deserialize()
-            .map_err(std::convert::Into::into)
+            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))
     }
 
-    fn unload(&self) -> anyhow::Result<bool> {
+    fn unload(&self) -> Result<bool> {
         self.dbus_connection
             .call_method(
                 Some("org.kde.KWin"),
@@ -89,10 +89,10 @@ impl KWinScript {
             )?
             .body()
             .deserialize()
-            .map_err(std::convert::Into::into)
+            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))
     }
 
-    fn start(&self, script_number: i32) -> anyhow::Result<()> {
+    fn start(&self, script_number: i32) -> Result<()> {
         debug!("Starting KWin script {script_number}");
 
         let path = if self.get_major_version() < 6 {
@@ -108,7 +108,7 @@ impl KWinScript {
                 "run",
                 &(),
             )
-            .with_context(|| "Error on starting the script")?;
+            .map_err(|_| Error::kwin_script_start_failed())?;
         Ok(())
     }
 
@@ -125,13 +125,13 @@ impl KWinScript {
         }
     }
 
-    fn get_major_version_from_env() -> anyhow::Result<i8> {
+    fn get_major_version_from_env() -> Result<i8> {
         env::var("KDE_SESSION_VERSION")?
             .parse::<i8>()
-            .map_err(std::convert::Into::into)
+            .map_err(Error::from)
     }
 
-    fn get_major_version_from_dbus(&self) -> anyhow::Result<i8> {
+    fn get_major_version_from_dbus(&self) -> Result<i8> {
         let support_information: String = self
             .dbus_connection
             .call_method(
@@ -142,22 +142,23 @@ impl KWinScript {
                 &(),
             )?
             .body()
-            .deserialize()?;
+            .deserialize()
+            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))?;
 
         // find a string like "KWin version: 5.27.8" and extract the version number from it:
         let version = support_information
             .lines()
             .find(|line| line.starts_with("KWin version: "))
-            .ok_or(anyhow!("KWin version not found"))?
+            .ok_or_else(Error::kwin_version_not_found)?
             .split_whitespace()
             .last()
-            .ok_or(anyhow!("KWin version is invalid"))?;
+            .ok_or_else(|| Error::kwin_version_invalid("version string is empty".to_string()))?;
 
         // Extract the major version number from the version number like "5.27.8":
         let major_version = version
             .split('.')
             .next()
-            .ok_or(anyhow!("KWin version is invalid: {version}"))?
+            .ok_or_else(|| Error::kwin_version_invalid(version.to_string()))?
             .parse::<i8>()?;
 
         debug!("KWin version from DBus: {version}, major version: {major_version}");
@@ -176,7 +177,7 @@ impl Drop for KWinScript {
 
 fn send_active_window(
     active_window: &Arc<Mutex<ActiveWindow>>,
-) -> anyhow::Result<ActiveWindowData> {
+) -> Result<ActiveWindowData> {
     let active_window = active_window.lock().expect("Mutex poisoned");
 
     Ok(ActiveWindowData {
@@ -245,7 +246,7 @@ pub struct KdeWindowManager {
 }
 
 impl KdeWindowManager {
-    pub fn new(config: WatcherConfig) -> anyhow::Result<Self> {
+    pub fn new(config: WatcherConfig) -> Result<Self> {
         let mut kwin_script = KWinScript::new(Connection::session()?);
         if kwin_script.is_loaded()? {
             debug!("KWin script is already loaded, unloading");
@@ -254,7 +255,7 @@ impl KdeWindowManager {
         if env::var("WAYLAND_DISPLAY").is_err()
             && env::var_os("XDG_SESSION_TYPE").unwrap_or("".into()) == "x11"
         {
-            return Err(anyhow!("X11 should be tried instead"));
+            return Err(Error::should_use_x11());
         }
 
         kwin_script.load().unwrap();
@@ -277,7 +278,7 @@ impl KdeWindowManager {
             .name("com.github.anoromi.whatawhat_lib")?
             .serve_at("/com/github/anoromi/whatawhat_lib", active_window_interface)?
             .build()
-            .map_err(|e| anyhow!("Failed to run a DBus interface: {e}"))?;
+            .map_err(|e| Error::dbus_interface_failed(e.to_string()))?;
 
         // Intentionally avoid initial monitor_activity() here to ensure we only process
         // events when the caller invokes methods (run-when-called semantics).

--- a/src/kde.rs
+++ b/src/kde.rs
@@ -56,7 +56,7 @@ impl KWinScript {
             )?
             .body()
             .deserialize()
-            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))
+            .map_err(Error::from)
     }
 
     fn get_registered_number(&self, path: &Path) -> Result<i32> {
@@ -75,7 +75,7 @@ impl KWinScript {
             )?
             .body()
             .deserialize()
-            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))
+            .map_err(Error::from)
     }
 
     fn unload(&self) -> Result<bool> {
@@ -89,7 +89,7 @@ impl KWinScript {
             )?
             .body()
             .deserialize()
-            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))
+            .map_err(Error::from)
     }
 
     fn start(&self, script_number: i32) -> Result<()> {
@@ -143,7 +143,7 @@ impl KWinScript {
             )?
             .body()
             .deserialize()
-            .map_err(|e| Error::from(crate::ErrorKind::Zbus(e)))?;
+            .map_err(Error::from)?;
 
         // find a string like "KWin version: 5.27.8" and extract the version number from it:
         let version = support_information

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 #[cfg(feature = "gnome")]
 pub mod gnome;
 #[cfg(feature = "kde")]
@@ -33,7 +34,7 @@ pub mod config;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+pub use error::{Error, ErrorKind, Result};
 #[cfg(any(
     feature = "x11",
     feature = "wayland",
@@ -162,7 +163,7 @@ impl GenericWindowManager {
         }
         #[allow(unreachable_code)]
         {
-            Err(anyhow::anyhow!("No window manager was selected"))
+            Err(Error::no_window_manager())
         }
     }
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -9,7 +9,6 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Result, anyhow};
 use objc2::{AllocAnyThread, rc::Retained};
 use objc2_core_graphics::{CGEventSource, CGEventSourceStateID, CGEventType};
 use objc2_foundation::{NSString, ns_string};
@@ -18,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use sysinfo::{self};
 
 use super::ActiveWindowData;
-use crate::{WindowManager, config::WatcherConfig};
+use crate::{Error, Result, WindowManager, config::WatcherConfig};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -62,18 +61,18 @@ impl WindowManager for MacosManger {
                 let mut err: Option<_> = None;
                 let data = unsafe { script.executeAndReturnError(err.as_mut()) };
                 if let Some(err) = err {
-                    return Err(anyhow!("execution error: {:?}", &err));
+                    return Err(Error::osa_script_execution_failed(format!("{:?}", &err)));
                 }
                 let json = unsafe {
-                    data.ok_or_else(|| anyhow!("No result from OSAScript execution"))?
+                    data.ok_or_else(|| Error::osa_script_no_result())?
                         .stringValue()
                 }
-                .ok_or_else(|| anyhow!("Script did not return a string value"))?
+                .ok_or_else(|| Error::osa_script_not_string())?
                 .to_string();
 
                 // Parse JXA output
                 let app_info: AppInfo = serde_json::from_str(&json)
-                    .map_err(|e| anyhow!("Failed to parse JXA JSON: {e}; payload: {json}"))?;
+                    .map_err(|e| Error::jxa_json_parse_failed(e.to_string(), json.clone()))?;
                 app_info
             }
             MacosRunner::SeparateProcess {
@@ -81,7 +80,7 @@ impl WindowManager for MacosManger {
             } => {
                 let app_info = current_app_info.lock().unwrap();
                 let Some(app_info) = app_info.as_ref() else {
-                    return Err(anyhow!("No app info was loaded"));
+                    return Err(Error::no_app_info_loaded());
                 };
                 app_info.clone()
             }
@@ -134,7 +133,7 @@ fn create_on_main_thread_osascript_process() -> Result<MacosRunner> {
     // Prepare OSAScript with JavaScript (JXA)
     let script = OSAScript::alloc();
     let language = unsafe { OSALanguage::languageForName(&NSString::from_str("JavaScript")) }
-        .ok_or_else(|| anyhow!("Failed to get JavaScript OSALanguage"))?;
+        .ok_or_else(|| Error::osa_language_not_found())?;
     let script = unsafe {
         OSAScript::initWithSource_language(
             script,
@@ -147,7 +146,7 @@ fn create_on_main_thread_osascript_process() -> Result<MacosRunner> {
     let mut err: Option<_> = None;
     let _ = unsafe { script.compileAndReturnError(err.as_mut()) };
     if let Some(err) = err {
-        return Err(anyhow!("compile error: {:?}", &err));
+        return Err(Error::osa_script_compilation_failed(format!("{:?}", &err)));
     }
 
     Ok(MacosRunner::OnMainThread { script })
@@ -201,7 +200,7 @@ fn collect_app_info(
     };
     let line = first_line.unwrap();
     let app_info: AppInfo = serde_json::from_str(&line).map_err(|e| {
-        anyhow!("Failed to parse JSON: {e}; line: {line}").context(MacosStartError(e.to_string()))
+        Error::macos_startup_failed(format!("Failed to parse JSON: {e}; line: {line}"))
     })?;
     {
         let mut current_app_info = info_mutex.lock().unwrap();
@@ -227,15 +226,6 @@ fn collect_app_info(
         }
     }
     Ok(())
-}
-
-#[derive(Debug)]
-struct MacosStartError(String);
-
-impl std::fmt::Display for MacosStartError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MacosPermissionsDenied: {}", self.0)
-    }
 }
 
 impl Drop for MacosRunner {

--- a/src/wayland_idle.rs
+++ b/src/wayland_idle.rs
@@ -1,7 +1,7 @@
 use crate::idle::{self, Status};
+use crate::{Error, Result};
 
 use super::wl_connection::{WlEventConnection, subscribe_state};
-use anyhow::Context as _;
 use chrono::{TimeDelta, Utc};
 use std::{
     sync::{Arc, Mutex, mpsc},
@@ -77,7 +77,7 @@ pub struct IdleWatcher {
 }
 
 impl IdleWatcher {
-    pub fn new(timeout: u32) -> anyhow::Result<Self> {
+    pub fn new(timeout: u32) -> Result<Self> {
         let mut connection: WlEventConnection<WatcherState> = WlEventConnection::connect()?;
         connection.get_ext_idle()?;
 
@@ -96,12 +96,12 @@ impl IdleWatcher {
         })
     }
 
-    pub fn run_iteration(&mut self) -> anyhow::Result<Status> {
+    pub fn run_iteration(&mut self) -> Result<Status> {
         self.connection
             .event_queue
             .roundtrip(&mut self.watcher_state)
-            .with_context(|| "Event queue is not processed")?;
-        Ok(self.watcher_state.idle_state.get_reactive(Utc::now())?)
+            .map_err(|e| Error::wayland_event_queue_failed(e.to_string()))?;
+        self.watcher_state.idle_state.get_reactive(Utc::now())
     }
 }
 
@@ -114,7 +114,7 @@ pub struct IdleWatcherRunner {
 const IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 
 impl IdleWatcherRunner {
-    pub fn new(timeout: u32) -> anyhow::Result<Self> {
+    pub fn new(timeout: u32) -> Result<Self> {
         let mut idle_watcher = IdleWatcher::new(timeout)?;
         let (stop_signal, stop_signal_receiver) = mpsc::channel();
         let current_idle_status = Arc::new(Mutex::new(None));

--- a/src/wayland_wlr.rs
+++ b/src/wayland_wlr.rs
@@ -1,4 +1,6 @@
 use crate::ActiveWindowData;
+use crate::Error;
+use crate::Result;
 use crate::WindowManager;
 use crate::config::WatcherConfig;
 use crate::idle::Status;
@@ -9,7 +11,6 @@ use crate::wayland_idle::IdleWatcherRunner;
 
 use super::wl_connection::WlEventConnection;
 use super::wl_connection::subscribe_state;
-use anyhow::anyhow;
 use std::collections::HashMap;
 use tracing::{debug, error, trace, warn};
 use wayland_client::{
@@ -128,7 +129,7 @@ pub struct WaylandWindowWatcherInner {
 }
 
 impl WaylandWindowWatcherInner {
-    pub fn new(config: WatcherConfig) -> anyhow::Result<Self> {
+    pub fn new(config: WatcherConfig) -> Result<Self> {
         let mut connection: WlEventConnection<ToplevelState> = WlEventConnection::connect()?;
         connection.get_foreign_toplevel_manager()?;
 
@@ -147,24 +148,22 @@ impl WaylandWindowWatcherInner {
         })
     }
 
-    pub fn run_iteration(&mut self) -> anyhow::Result<ActiveWindowData> {
+    pub fn run_iteration(&mut self) -> Result<ActiveWindowData> {
         self.connection
             .event_queue
             .roundtrip(&mut self.toplevel_state)
-            .map_err(|e| anyhow!("Event queue is not processed: {e}"))?;
+            .map_err(|e| Error::wayland_event_queue_failed(e.to_string()))?;
 
         let active_window_id = self
             .toplevel_state
             .current_window_id
             .as_ref()
-            .ok_or(anyhow!("Current window is unknown"))?;
+            .ok_or_else(Error::current_window_unknown)?;
         let active_window = self
             .toplevel_state
             .windows
             .get(active_window_id)
-            .ok_or(anyhow!(
-                "Current window is not found by ID {active_window_id}"
-            ))?;
+            .ok_or_else(|| Error::window_not_found_by_id(active_window_id.clone()))?;
 
         let (process_path, app_name) = match self.desktop_info_cache.get(&active_window.app_id) {
             Some(extra_info) => (extra_info.process_path, extra_info.app_name),
@@ -197,7 +196,7 @@ pub struct WaylandWindowWatcher {
 }
 
 impl WaylandWindowWatcher {
-    pub fn new(config: WatcherConfig) -> anyhow::Result<Self> {
+    pub fn new(config: WatcherConfig) -> Result<Self> {
         let window_watcher = WaylandWindowWatcherInner::new(config.clone())?;
         Ok(Self {
             inner: window_watcher,
@@ -213,11 +212,11 @@ impl Drop for WaylandWindowWatcher {
 }
 
 impl WindowManager for WaylandWindowWatcher {
-    fn get_active_window_data(&mut self) -> anyhow::Result<ActiveWindowData> {
+    fn get_active_window_data(&mut self) -> Result<ActiveWindowData> {
         self.inner.run_iteration()
     }
 
-    fn is_idle(&mut self) -> anyhow::Result<bool> {
+    fn is_idle(&mut self) -> Result<bool> {
         let status_guard = self.idle_watcher.current_idle_status.lock().unwrap();
         match *status_guard {
             Some(Status::Active { .. }) => Ok(false),

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,11 +1,10 @@
-//! Contains logic for extracting records through x11. The implementation uses xcb for communication
-//! with the server.
+//! Contains logic for extracting records through Windows APIs.
 
 use crate::{
+    Error, Result,
     config::WatcherConfig,
     windows_desktop::{WindowsAppInfo, WindowsDesktopInfo},
 };
-use anyhow::{Result, anyhow};
 use tracing::error;
 use windows::{
     Win32::{
@@ -74,7 +73,7 @@ fn get_active_windows_data(
         let window = unsafe { GetForegroundWindow() };
 
         if window.is_invalid() {
-            return Err(anyhow!("Failed to get foreground window"));
+            return Err(Error::foreground_window_not_found());
         }
 
         let mut id = 0u32;
@@ -95,11 +94,11 @@ fn get_active_windows_data(
                 )
             };
             if size == 0 {
-                return Err(anyhow!("Failed to get active window"));
+                return Err(Error::active_window_not_found("unknown error"));
             } else {
                 let data = String::from_utf16(&message_buffer[0..size as usize])
                     .expect("Failed to unwrap");
-                return Err(anyhow!("Failed to get active window {data}"));
+                return Err(Error::active_window_not_found(data));
             }
         }
         let process_handle =
@@ -144,7 +143,7 @@ pub fn get_idle_time() -> Result<u64> {
     let is_success = unsafe { GetLastInputInfo(&mut last) };
     if !is_success.as_bool() {
         error!("Failed to retrieve user idle time");
-        return Err(anyhow!("Failed to retrieve user idle time"));
+        return Err(Error::idle_time_retrieval_failed());
     }
 
     let tick_count = unsafe { GetTickCount64() };

--- a/src/wl_connection.rs
+++ b/src/wl_connection.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use crate::{Error, Result};
 use wayland_client::{
     Connection, Dispatch, EventQueue, Proxy, QueueHandle,
     globals::{GlobalList, GlobalListContents, registry_queue_init},
@@ -42,9 +42,9 @@ where
         + Dispatch<wl_registry::WlRegistry, ()>
         + 'static,
 {
-    pub fn connect() -> anyhow::Result<Self> {
+    pub fn connect() -> Result<Self> {
         let connection = Connection::connect_to_env()
-            .with_context(|| "Unable to connect to Wayland compositor")?;
+            .map_err(|_| Error::wayland_connection_failed())?;
         let display = connection.display();
         let (globals, event_queue) = registry_queue_init::<T>(&connection)?;
 
@@ -59,7 +59,7 @@ where
         })
     }
 
-    pub fn get_foreign_toplevel_manager(&self) -> anyhow::Result<ZwlrForeignToplevelManagerV1>
+    pub fn get_foreign_toplevel_manager(&self) -> Result<ZwlrForeignToplevelManagerV1>
     where
         T: Dispatch<ZwlrForeignToplevelManagerV1, ()>,
     {
@@ -69,10 +69,10 @@ where
                 1..=ZwlrForeignToplevelManagerV1::interface().version,
                 (),
             )
-            .map_err(std::convert::Into::into)
+            .map_err(Error::from)
     }
 
-    pub fn get_kwin_idle(&self) -> anyhow::Result<OrgKdeKwinIdle>
+    pub fn get_kwin_idle(&self) -> Result<OrgKdeKwinIdle>
     where
         T: Dispatch<OrgKdeKwinIdle, ()>,
     {
@@ -82,10 +82,10 @@ where
                 1..=OrgKdeKwinIdle::interface().version,
                 (),
             )
-            .map_err(std::convert::Into::into)
+            .map_err(Error::from)
     }
 
-    pub fn get_ext_idle(&self) -> anyhow::Result<ExtIdleNotifierV1>
+    pub fn get_ext_idle(&self) -> Result<ExtIdleNotifierV1>
     where
         T: Dispatch<ExtIdleNotifierV1, ()>,
     {
@@ -95,10 +95,10 @@ where
                 1..=ExtIdleNotifierV1::interface().version,
                 (),
             )
-            .map_err(std::convert::Into::into)
+            .map_err(Error::from)
     }
 
-    pub fn get_ext_idle_notification(&self, timeout: u32) -> anyhow::Result<ExtIdleNotificationV1>
+    pub fn get_ext_idle_notification(&self, timeout: u32) -> Result<ExtIdleNotificationV1>
     where
         T: Dispatch<ExtIdleNotifierV1, ()>
             + Dispatch<WlSeat, ()>
@@ -112,7 +112,7 @@ where
         Ok(idle.get_idle_notification(timeout, &seat, &self.queue_handle, ()))
     }
 
-    pub fn get_kwin_idle_timeout(&self, timeout: u32) -> anyhow::Result<OrgKdeKwinIdleTimeout>
+    pub fn get_kwin_idle_timeout(&self, timeout: u32) -> Result<OrgKdeKwinIdleTimeout>
     where
         T: Dispatch<OrgKdeKwinIdle, ()>
             + Dispatch<OrgKdeKwinIdleTimeout, ()>

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -3,7 +3,6 @@
 
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
 use sysinfo::Pid;
 use tracing::{error, instrument};
 use xcb::{
@@ -12,7 +11,7 @@ use xcb::{
     x::{self, ATOM_ANY, Atom, Drawable, GetProperty, InternAtom, Window},
 };
 
-use super::{ActiveWindowData, WindowManager, config::WatcherConfig};
+use super::{ActiveWindowData, Error, Result, WindowManager, config::WatcherConfig};
 
 fn get_pid_atom(conn: &Connection) -> Result<Atom> {
     let reply = conn.wait_for_reply(conn.send_request(&InternAtom {
@@ -112,9 +111,9 @@ impl WindowData {
             get_active_window(&self.connection, &default_window, self.active_window_atom)?;
         let window_name = get_name(&self.connection, active_window, self.window_name_atom)?;
         let process = get_pid(&self.connection, active_window, self.pid_atom)?
-            .ok_or_else(|| anyhow!("Failed to get pid: pid is None"))?;
+            .ok_or_else(Error::process_id_not_found)?;
         let process_name = get_process_name(process)?
-            .ok_or_else(|| anyhow!("Failed to get process name: process name is None"))?;
+            .ok_or_else(Error::process_name_not_found)?;
 
         Ok(ActiveWindowData {
             window_title: window_name.into(),
@@ -142,9 +141,7 @@ impl LinuxWindowManager {
         let (connection, preferred_screen) = xcb::Connection::connect(None)
             .inspect_err(|e| error!("Failed creating connection {e:?}"))?;
         if preferred_screen < 0 {
-            return Err(anyhow!(
-                "Preferred screen is less than 0 {preferred_screen}"
-            ));
+            return Err(Error::x11_invalid_screen(preferred_screen));
         }
         let preferred_screen = preferred_screen as usize;
         let active_window_atom = get_active_window_atom(&connection)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a typed, cross-platform error model and removes `anyhow`.
> 
> - Add `src/error.rs` with `Error`, `ErrorKind`, and domain-specific enums (`WindowError`, `IdleError`, `PlatformError` with `X11Error`/`WaylandError`/`DbusError`/`GnomeError`/`KdeError`/`MacosError`/`WindowsError`), `From` impls, and convenience constructors
> - Replace `anyhow::Result` with crate `Result` and map errors explicitly in `gnome.rs`, `kde.rs`, `wayland_idle.rs`, `wayland_wlr.rs`, `wl_connection.rs`, `x11.rs`, `win.rs`, `macos.rs`, `idle.rs`, and plumb through `GenericWindowManager` in `lib.rs`
> - Improve error propagation: convert DBus, Wayland queue/connection, X11/XCB, Windows API, and macOS OSAScript failures to specific errors; add targeted messages (e.g., `should_use_x11`, `current_window_unknown`, `kwin_version_*`)
> - Update `Cargo.toml` to remove `anyhow` and add `thiserror`; export `error` module and re-export `Error`/`ErrorKind`/`Result`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e01c46051ef506e2e06f98c78edd0d1d5d8cefef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->